### PR TITLE
Use BOM encoding to remove mark from start of file on windows

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: specio
 Title: Read Spectrum Files
-Version: 0.1.0
+Version: 0.1.1
 Authors@R: 
     person(given = "Robert",
            family = "Ashton",

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,7 @@
+## 0.1.1
+
+Fix bug on windows where read.csv including byte order mark in column names of DP file
+
 ## 0.1.0
 
 Add extract_population and extract_hiv_population methods

--- a/R/file_utils.R
+++ b/R/file_utils.R
@@ -89,5 +89,9 @@ get_pjn_data <- function(pjnz_path) {
 #' specio:::get_pjnz_csv_data(pjnz, "PJN")
 get_pjnz_csv_data <- function(pjnz_path, extension) {
   file <- get_filename_from_extension(extension, pjnz_path)
-  csv <- utils::read.csv(unz(pjnz_path, file), as.is = TRUE)
+  ## Use UTF-8-BOM encoding to remove the Byte order mark at the start of the
+  ## file if it is present. This is ignored by default on Linux but included
+  ## when reading the file on windows.
+  csv <- utils::read.csv(unz(pjnz_path, file), stringsAsFactors = FALSE,
+                         encoding = "UTF-8-BOM")
 }

--- a/README.md
+++ b/README.md
@@ -12,7 +12,9 @@ As well as the functions required for EPP `specio` also provides 2 more general 
 
 ## Installation
 
+To install internally released version via drat:
 ```r
-# install.packages("devtools")
-devtools::install_github("mrc-ide/specio")
+# install.packages("drat") # (if needed)
+drat:::add("mrc-ide")
+install.packages("specio")
 ```


### PR DESCRIPTION
This PR will
* Use `UTF-8-BOM` encoding when calling `read.csv` to strip byte order mark on windows machines
* Also sneaked in a an update to `README.md` to use drat to install the package

This isn't tested as I can't think of a way of writing a good test for this which would fail on a Linux machine. As it is a simple fix I figured it would be okay this case? I can try and add a test if you feel strongly otherwise.

Fixes #10 