### PR TITLE
Fix BOM error for windows users

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: specio
 Title: Read Spectrum Files
-Version: 0.1.2
+Version: 0.1.3
 Authors@R: 
     person(given = "Robert",
            family = "Ashton",
@@ -12,6 +12,7 @@ Encoding: UTF-8
 LazyData: true
 Imports:
     beers,
+    readr,
     xml2,
     yaml
 Remotes:

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -12,7 +12,6 @@ Encoding: UTF-8
 LazyData: true
 Imports:
     beers,
-    readr,
     xml2,
     yaml
 Remotes:

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -17,6 +17,7 @@ Imports:
 Remotes:
     mrc-ide/beers
 Suggests: 
+    mockery,
     testthat,
     knitr,
     rmarkdown

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,7 @@
+## 0.1.3
+
+Fix windows BOM bug using manual column name fix
+
 ## 0.1.2
 
 Fix bug reading Spectrum 2019 files

--- a/R/file_utils.R
+++ b/R/file_utils.R
@@ -89,11 +89,19 @@ get_pjn_data <- function(pjnz_path) {
 #' specio:::get_pjnz_csv_data(pjnz, "PJN")
 get_pjnz_csv_data <- function(pjnz_path, extension) {
   file <- get_filename_from_extension(extension, pjnz_path)
-  csv <- utils::read.csv(unz(pjnz_path, file), stringsAsFactors = FALSE)
-  ## Set column name of first column manually to remove any possible byte order
-  ## mark added when reading the file on windows. We should be able to work
-  ## around this by passing encoding = "UTF-8-BOM" or fileEncoding = "UTF-8-BOM"
-  ## as arg to read.csv but this isn't working reliably.
-  colnames(csv)[[1]] <- "Tag"
+  csv <- read_csv(unz(pjnz_path, file))
+  ## If the first column name has preceeding bytes then manually strip them.
+  ## This works around reading files on windows with a preceeding BOM. We
+  ## should be able to work around this by passing encoding = "UTF-8-BOM" or
+  ## fileEncoding = "UTF-8-BOM" as arg to read.csv but this isn't working
+  ## reliably.
+  bytes <- charToRaw(colnames(csv)[[1]])
+  if (length(bytes) > 3 && identical(tail(bytes, 3), charToRaw("Tag"))) {
+    colnames(csv)[[1]] <- "Tag"
+  }
   csv
+}
+
+read_csv <- function(file) {
+  utils::read.csv(file, stringsAsFactors = FALSE)
 }

--- a/R/file_utils.R
+++ b/R/file_utils.R
@@ -74,7 +74,7 @@ get_pjn_data <- function(pjnz_path) {
   get_pjnz_csv_data(pjnz_path, "PJN")
 }
 
-#' Get csv data from file containing within PJNZ
+#' Get csv data from file contained within PJNZ
 #'
 #' @param pjnz_path Path to PJNZ zip file.
 #' @param extension The file extension to look for.
@@ -89,9 +89,11 @@ get_pjn_data <- function(pjnz_path) {
 #' specio:::get_pjnz_csv_data(pjnz, "PJN")
 get_pjnz_csv_data <- function(pjnz_path, extension) {
   file <- get_filename_from_extension(extension, pjnz_path)
-  ## Use UTF-8-BOM encoding to remove the Byte order mark at the start of the
-  ## file if it is present. This is ignored by default on Linux but included
-  ## when reading the file on windows.
-  csv <- utils::read.csv(unz(pjnz_path, file), stringsAsFactors = FALSE,
-                         encoding = "UTF-8-BOM")
+  csv <- utils::read.csv(unz(pjnz_path, file), stringsAsFactors = FALSE)
+  ## Set column name of first column manually to remove any possible byte order
+  ## mark added when reading the file on windows. We should be able to work
+  ## around this by passing encoding = "UTF-8-BOM" or fileEncoding = "UTF-8-BOM"
+  ## as arg to read.csv but this isn't working reliably.
+  colnames(csv)[[1]] <- "Tag"
+  csv
 }

--- a/man/get_pjnz_csv_data.Rd
+++ b/man/get_pjnz_csv_data.Rd
@@ -2,7 +2,7 @@
 % Please edit documentation in R/file_utils.R
 \name{get_pjnz_csv_data}
 \alias{get_pjnz_csv_data}
-\title{Get csv data from file containing within PJNZ}
+\title{Get csv data from file contained within PJNZ}
 \usage{
 get_pjnz_csv_data(pjnz_path, extension)
 }
@@ -15,7 +15,7 @@ get_pjnz_csv_data(pjnz_path, extension)
 The data from file read as a csv.
 }
 \description{
-Get csv data from file containing within PJNZ
+Get csv data from file contained within PJNZ
 }
 \examples{
 pjnz <- system.file("testdata", "Botswana2018.PJNZ", package = "specio")

--- a/tests/testthat/helper_xml_utils.R
+++ b/tests/testthat/helper_xml_utils.R
@@ -1,3 +1,3 @@
-files <- dir("xml_testdata", full.name = TRUE)
+files <- dir("xml_testdata", full.names = TRUE)
 xml_testdata <- lapply(files, xml2::read_xml)
 names(xml_testdata) <- sub(".xml$", "", basename(files))

--- a/tests/testthat/test_file_utils.R
+++ b/tests/testthat/test_file_utils.R
@@ -39,3 +39,20 @@ test_that("DP and PJN data can be read", {
   expect_length(names(pjn_data), 59)
 })
 
+test_that("reading csv data correctly strips any preceeding BOM", {
+  pjnz <- system.file("testdata", "Botswana2018.PJNZ", package = "specio")
+  data <- get_pjnz_csv_data(pjnz, "DP")
+  ## Not a problem on Linux machines
+  expect_equal(colnames(data)[[1]], "Tag")
+
+  ## Mock windows response
+  file <- get_filename_from_extension("DP", pjnz)
+  csv <- read_csv(unz(pjnz, file))
+  colnames(csv)[[1]] <- paste0("ï..", colnames(csv)[[1]])
+  mock_read_csv <- mockery::mock(csv)
+  with_mock("specio:::read_csv" = mock_read_csv, {
+    data <- get_pjnz_csv_data(pjnz, "DP")
+  })
+  expect_equal(colnames(data)[[1]], "Tag")
+})
+


### PR DESCRIPTION
This PR will

* Fix BOM error for windows users by manually fixing the first column name

This is a bit of a hacky fix and not really ideal. I think it will probably suffice for now and we can look at fixing this properly when we have more time. Have investigated using `readr` to try and fix this which works around the BOM error but throws lots of warnings related to missing column headers which we don't really want.